### PR TITLE
fixes and improvements on the `@@` notation

### DIFF
--- a/program/annotations.py
+++ b/program/annotations.py
@@ -74,7 +74,7 @@ def get_annotation_from_file(path: str, errata_list: list, patches: dict, rfc_li
                 if is_plain_text:
                     notes.append("</pre>")
                 else:
-                    notes = htmlfilter.filter_html(notes, path=path)
+                    notes = util.rewrite_rfc_anchors(htmlfilter.filter_html(notes, path=path), rfc_list)
                 entry["notes"] = notes
                 ret.append(check_errata_status(entry))
                 notes = []


### PR DESCRIPTION
1. The `@@` notation did not work if multiple annotations have been embedded in one singe file. This is fixed.
2. The @@ syntax is improved an supports 

- `@@RFC<nr>:<anchor>@@` eg. `@@RFC1034:line-1@@` or `@@RFC1034:section-1@@`
- `@@line xyz [any text] RFC<nr>@@` eg. `@@Line 1 in RFC1034@@` or `@@line 123 of RFC1034@@`
- `@@section xyz [any text] RFC<nr>@@` eg. `@@Section 1 in RFC1034@@` or `@@section 1.1 mentioned in RFC1034@@`