### PR TITLE
rfc list files can contain multiple sections

### DIFF
--- a/default-config/index-scripts.html
+++ b/default-config/index-scripts.html
@@ -1,21 +1,24 @@
 <script>
 directions = []
 
-function makeTableSortable(tableId) {
-    const table = document.getElementById(tableId);
-    const headers = table.querySelectorAll('th');
-    [].forEach.call(headers, function (header, index) {
-        header.addEventListener('click', function () {
-            sortColumn(index);
+function makeTableSortable(tablePrefix, count) {
+    for (let i = 0; i<count; i++) {
+        const tableId = tablePrefix + i;
+        const table = document.getElementById(tableId);
+        const headers = table.querySelectorAll('th');
+        [].forEach.call(headers, function (header, index) {
+            header.addEventListener('click', function () {
+                sortColumn(index, tableId);
+            });
         });
-    });
-    directions = Array.from(headers).map(function (header) {
-        return 'asc';
-    });
+        directions = Array.from(headers).map(function (header) {
+            return 'asc';
+        });
+    }
 }
 
-function sortColumn(index) {
-    const table = document.getElementById('rfcs');
+function sortColumn(index, tableId) {
+    const table = document.getElementById(tableId);
     const headers = table.querySelectorAll('th');
     const transform = function (index, content) {
         const type = headers[index].getAttribute('data-type');


### PR DESCRIPTION
rfc list files can contain multiple sections (divided by a line just containing 20 '#' characters).

Example:
[http-rfcs.txt](https://github.com/icann/rfc-annotations/files/9306787/http-rfcs.txt)

Results in (blame GitHub for the zip-format, html is not allowed):
[http-index.html.zip](https://github.com/icann/rfc-annotations/files/9306792/http-index.html.zip)

