### PR TITLE
Send along a User-Agent header with urlopen

### DIFF
--- a/program/drafts.py
+++ b/program/drafts.py
@@ -2,10 +2,9 @@ import json
 import os
 import subprocess
 from typing import Optional
-from urllib.request import urlopen
 from xml.dom.minidom import Document, parseString, Element
 
-import util  # filtered_files, debug, info, error
+import util  # filtered_files, debug, info, error, urlopen
 
 ''' Read and process Internet Drafts for RFC annotations tools '''
 
@@ -77,7 +76,7 @@ def get_draft_status(directory: str, url: str = "https://www.ietf.org/id/all_id.
     if document is None:
         util.info(f"\nFetching draft status from source of truth {url}... ", end='')
         try:
-            text_content = urlopen(url).read().decode('utf-8')
+            text_content = util.urlopen(url).read().decode('utf-8')
             util.info(f"Retrieved {len(text_content)} chars of data. Parsing and converting...", end='')
             document = {}
             for entry in text_content.split("\n"):

--- a/program/errata.py
+++ b/program/errata.py
@@ -1,9 +1,8 @@
 import json
 import os
 from typing import Optional
-from urllib.request import urlopen
 
-import util  # correct_path, create_checksum, config_directories, debug, info, error
+import util  # correct_path, create_checksum, config_directories, debug, info, error, urlopen
 
 ''' Create errata for RFC annotations tools '''
 
@@ -22,7 +21,7 @@ def read_errata(path: str = ".", url: str = "https://www.rfc-editor.org/errata.j
     if document is None:
         util.info(f"\nFetching errata from source of truth {url}... ", end='')
         try:
-            json_content = urlopen(url).read()
+            json_content = util.urlopen(url).read()
             util.info("Done")
             if type(json_content) is bytes:
                 util.debug(f"Retrieved {len(json_content)} bytes of data. Parsing... ", end='')

--- a/program/pull_updates.py
+++ b/program/pull_updates.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import os.path
 import subprocess
-import urllib.request
+import util  # urlopen
 from pathlib import Path
 
 ''' Program to get updates to annotations from remote locations '''
@@ -97,7 +97,7 @@ def process_config_content(config):
                     handle_git(this_url, target_dir)
                     continue
                 try:
-                    with urllib.request.urlopen(this_url) as f:
+                    with util.urlopen(this_url) as f:
                         web_contents = f.read().decode('latin-1')
                 except Exception as e:
                     print(f"** Error reading {this_url}: {e}. Skipping.")

--- a/program/rfcfile.py
+++ b/program/rfcfile.py
@@ -1,7 +1,6 @@
 import os
-from urllib.request import urlopen
 
-import util  # correct_path, debug, info, error
+import util  # correct_path, debug, info, error, urlopen
 
 ''' Download the RFC files for RFC annotations tools '''
 
@@ -24,7 +23,7 @@ def download_rfcs(rfc_list: list, directory: str = "."):
         else:
             util.info(f"Downloading {rfc.ljust(7)}... ", end='')
             try:
-                content = urlopen(f"https://www.rfc-editor.org/rfc/{rfc}.txt").read()
+                content = util.urlopen(f"https://www.rfc-editor.org/rfc/{rfc}.txt").read()
                 if type(content) is bytes:
                     util.info(f"Retrieved {str(len(content)).rjust(6)} bytes of data.")
                     with open(filename, "wb") as f:

--- a/program/util.py
+++ b/program/util.py
@@ -3,6 +3,7 @@ import hashlib
 import re
 import sys
 from typing import Optional
+import urllib.request
 
 ''' Utility functions for RFC annotations tools '''
 
@@ -193,3 +194,6 @@ def means_true(s: str) -> bool:
 
 def config_directories() -> [str]:
     return ["default-config"] if _running_in_test else ["local-config", "default-config"]
+
+def urlopen(url):
+	return urllib.request.urlopen(urllib.request.Request(url, headers ={'User-Agent': 'Mozilla/5.0'}))


### PR DESCRIPTION
Because www.rfc-editor.org returns 403: Forbidden otherwise:
```
Fetching errata from source of truth https://www.rfc-editor.org/errata.json... 

   ERROR: returned with error: HTTP Error 403: Forbidden.



   ERROR: got unexpected parsing response type <class 'NoneType'>.


Creating output for dns-rfcs.txt...
Scanning for 144 RFC documents in 'raw-originals/':
Downloading rfc1034... 

   ERROR: can't download text file for rfc1034: HTTP Error 403: Forbidden.

Downloading rfc1035... 

   ERROR: can't download text file for rfc1035: HTTP Error 403: Forbidden.
```
etc. At least with me.

According to [this stackoverflow issue](https://stackoverflow.com/questions/47594331/python-3-urlopen-http-error-403-forbidden) because the server denies bot access.